### PR TITLE
Fix Taproot key generation for FROST

### DIFF
--- a/frost-client/src/cli/coordinator.rs
+++ b/frost-client/src/cli/coordinator.rs
@@ -11,17 +11,7 @@ use frost_core::Ciphersuite;
 use frost_ed25519::Ed25519Sha512;
 use frost_rerandomized::RandomizedCiphersuite;
 use frost_secp256k1_tr::Secp256K1Sha256TR;
-use bitcoin::{
-    hashes::{sha256, Hash},
-    key::XOnlyPublicKey,
-    secp256k1::Scalar as SecScalar,
-};
-use k256::{Scalar, FieldBytes};
-use k256::elliptic_curve::{
-    bigint::U256,
-    ops::Reduce,
-};
-use crate::util::taproot::tweak_internal_key;
+
 use reddsa::frost::redpallas::PallasBlake2b512;
 use reqwest::Url;
 
@@ -133,49 +123,7 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
 
     cli::cli_for_processed_args(pargs, &mut input, &mut output).await?;
 
-    // ---------------------------------------------------------------------
-    // Patch s = s + e·t  after shares are combined (automatic for secp256k1-tr)
-    if C::ID == Secp256K1Sha256TR::ID && !signature.is_empty() {
-    // fetch P or fail with a plain String so `?` coerces into `Box<dyn Error>`
-    let p_bytes = group
-        .internal_key
-        .clone()
-        .ok_or::<Box<dyn std::error::Error>>("internal_key missing; run DKG with secp256k1-tr ciphersuite".into())?;
-        let p_xonly = XOnlyPublicKey::from_slice(&p_bytes).unwrap();
-        let (q_key, tweak_scalar) = tweak_internal_key(p_xonly);
 
-        // we signed exactly one message
-        let msg = &messages_vec[0];
-
-        // read raw sig
-        let mut sig = std::fs::read(&signature)
-            .wrap_err("cannot read signature file for tweaking")?;
-        if sig.len() != 64 {
-            return Err(eyre!("signature length is not 64 bytes").into());
-        }
-
-        // e = H(Rx ‖ Qx ‖ m)
-        let r_x = &sig[..32];
-        let e_scalar_secp = SecScalar::from_be_bytes(
-            sha256::Hash::hash(&[r_x, &q_key.serialize(), msg].concat()).to_byte_array(),
-        )
-        .unwrap();
-
-        // Convert raw big-endian bytes into k256 scalars **with modular reduction**
-        let s_orig  =
-            <Scalar as Reduce<U256>>::reduce_bytes(FieldBytes::from_slice(&sig[32..]));
-        let t_k =
-            <Scalar as Reduce<U256>>::reduce_bytes(FieldBytes::from_slice(&tweak_scalar.to_be_bytes()));
-        let e_k =
-            <Scalar as Reduce<U256>>::reduce_bytes(FieldBytes::from_slice(&e_scalar_secp.to_be_bytes()));
-
-        // new_s = s + t·e  (mod n)
-        let new_s = s_orig + t_k * e_k;
-        sig[32..].copy_from_slice(new_s.to_bytes().as_slice());
-
-        std::fs::write(&signature, &sig)?;
-        eprintln!("Taproot tweak applied to {}", signature);
-    }
 
     Ok(())
 }

--- a/frost-client/src/cli/dkg.rs
+++ b/frost-client/src/cli/dkg.rs
@@ -6,7 +6,7 @@ use std::{
 
 use eyre::{eyre, Context as _, OptionExt};
 
-use frost_core::Ciphersuite;
+use frost_core::{Ciphersuite, keys::KeyPackage};
 use frost_ed25519::Ed25519Sha512;
 use frost_secp256k1_tr::Secp256K1Sha256TR;
 use bitcoin::key::XOnlyPublicKey;
@@ -109,8 +109,18 @@ pub(crate) async fn dkg_for_ciphersuite<C: Ciphersuite + MaybeIntoEvenY + 'stati
     };
 
     // Generate key shares
-    let (key_package, mut public_key_package, pubkey_map) =
+    let (mut key_package, mut public_key_package, pubkey_map) =
         cli::cli_for_processed_args::<C>(dkg_config, &mut input, &mut output).await?;
+
+    if C::ID == Secp256K1Sha256TR::ID {
+        use frost_secp256k1_tr::keys::Tweak;
+        let bytes = key_package.serialize()?;
+        let kp_tr = frost_secp256k1_tr::keys::KeyPackage::deserialize(&bytes)?;
+        let kp_tr = kp_tr.tweak::<&[u8]>(None);
+        let bytes = kp_tr.serialize()?;
+        key_package = KeyPackage::deserialize(&bytes)?;
+    }
+
     let key_package = Zeroizing::new(key_package);
 
     // ---------------------------------------------------------------------

--- a/frost-client/src/cli/trusted_dealer.rs
+++ b/frost-client/src/cli/trusted_dealer.rs
@@ -125,7 +125,16 @@ pub(crate) fn trusted_dealer_for_ciphersuite<C: Ciphersuite + MaybeIntoEvenY + '
         // into a KeyPackage without first checking if
         // [`SecretShare::commitment()`] is the same for all participants using
         // a broadcast channel.
-        let key_package: KeyPackage<C> = share.clone().try_into()?;
+        let mut key_package: KeyPackage<C> = share.clone().try_into()?;
+        if C::ID == Secp256K1Sha256TR::ID {
+            use frost_secp256k1_tr::keys::Tweak;
+            // Convert to the secp256k1-tr concrete type via serialization
+            let bytes = key_package.serialize()?;
+            let kp_tr = frost_secp256k1_tr::keys::KeyPackage::deserialize(&bytes)?;
+            let kp_tr = kp_tr.tweak::<&[u8]>(None);
+            let bytes = kp_tr.serialize()?;
+            key_package = KeyPackage::deserialize(&bytes)?;
+        }
         let group = Group {
             ciphersuite: C::ID.to_string(),
             description: description.clone(),


### PR DESCRIPTION
## Summary
- tweak key packages when generating secp256k1-tr shares
- drop signature post-processing logic in coordinator

## Testing
- `cargo test -p frost-client --quiet`
- `cargo test --workspace --exclude tests --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688836f873188325a9cefdc5f4408e47